### PR TITLE
chore(style): add editorconfig & vscode ignoer for vscode user

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 /.idea/
+.vscode
 /vendor/
 /go.sum
 *.DS_Store


### PR DESCRIPTION
## Description

Hi, I noticed this framework during this sharing session，And intersting in it , but I prefer to use `vscode` as a development tool.
I noticed this project don't ignore `.vscode` dir , and no uniform development indentation specification.
So I add it.

## CheckList

- [x] Add `.vscode` as git ignore.
- [x] Add `.editorconfig` for vsocde.  
